### PR TITLE
Find assets when mounting sinatra app in rails/ rails engine

### DIFF
--- a/lib/girl_friday/server.rb
+++ b/lib/girl_friday/server.rb
@@ -16,7 +16,7 @@ module GirlFriday
     set :views,  "#{basedir}/views"
     set :public, "#{basedir}/public"
     set :static, true
-    
+
     helpers do
       include Rack::Utils
       alias_method :h, :escape_html
@@ -30,10 +30,19 @@ module GirlFriday
           ['white', 'OK']
         end
       end
+
+      def url_path(*path_parts)
+        [path_prefix, path_parts].join('/').squeeze('/')
+      end
+      alias_method :u, :url_path
+
+      def path_prefix
+        request.env['SCRIPT_NAME']
+      end
     end
-    
-    get '/' do
-      redirect "#{request.env['REQUEST_URI']}/status"
+
+    get '/?' do
+      redirect url_path('status')
     end
 
     get '/status' do

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>girl_friday status</title>
-    <link href="/css/style.css"  media="screen" rel="stylesheet" type="text/css" />
+    <link href="<%=u 'css/style.css' %>" media="screen" rel="stylesheet" type="text/css">
   </head>
   <body>
     <style>


### PR DESCRIPTION
Hi Mike,

apparently, if you mount the sinatra app in rails config/routes.rb via

> require 'girl_friday/server'
> mount GirlFriday::Server => '/girl_friday'

it won't find any assets.

So I fixed this by adding the 'SCRIPT_NAME' environment variable to the path.

Maybe you want to pull this in.

Thanks for the great work with this gem.

Cheers
