### PR TITLE
Immediate processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.rbxdb/

--- a/History.md
+++ b/History.md
@@ -8,12 +8,13 @@ HEAD
   instead.
 * Add support for Batch operations, providing an easy way to fan out
   operations and then collect results when completed.
+* [jc00ke](https://github.com/jc00ke) added WorkQueue.immediate! and WorkQueue.queue! to switch background processing off and back on respectively. Nice to use when testing.
 
 0.9.1
 ---------
 
 * Lazy initialize the worker actors to avoid dead thread problems with Unicorn forking processes.
-* Add initial pass at girl_friday Rack server (see wiki).  It's awful looking, trust me, help wanted.
+* Add initial pass at girl\_friday Rack server (see wiki).  It's awful looking, trust me, help wanted.
 
 
 0.9.0

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-girl_friday
+girl\_friday
 ====================
 
-Have a task you want to get done sometime soon but don't want to do it yourself?  Give it to girl_friday!  From wikipedia:
+Have a task you want to get done sometime soon but don't want to do it yourself?  Give it to girl\_friday!  From wikipedia:
 
 > The term Man Friday has become an idiom, still in mainstream usage, to describe an especially faithful servant or
 > one's best servant or right-hand man. The female equivalent is Girl Friday. The title of the movie His Girl Friday
 > alludes to it and may have popularized it.
 
-girl_friday is a Ruby library for performing asynchronous tasks.  Often times you don't want to block a web response by performing some task, like sending an email, so you can just use this gem to perform it in the background.  It works with any Ruby application, including Rails 3 applications.
+girl\_friday is a Ruby library for performing asynchronous tasks.  Often times you don't want to block a web response by performing some task, like sending an email, so you can just use this gem to perform it in the background.  It works with any Ruby application, including Rails 3 applications.
 
 
 Installation
 ------------------
 
-We recommend using [JRuby 1.6+](http://jruby.org) or [Rubinius 2.0+](http://rubini.us) with girl_friday.  Both are excellent options for executing Ruby these days.
+We recommend using [JRuby 1.6+](http://jruby.org) or [Rubinius 2.0+](http://rubini.us) with girl\_friday.  Both are excellent options for executing Ruby these days.
 
     gem install girl_friday
 
-girl_friday does not support Ruby 1.8 (MRI) because of its poor threading support.  Ruby 1.9 will work reasonably well if you use gems that release the GIL for network I/O (mysql2 is a good example of this, do **not** use the original mysql gem).
+girl\_friday does not support Ruby 1.8 (MRI) because of its poor threading support.  Ruby 1.9 will work reasonably well if you use gems that release the GIL for network I/O (mysql2 is a good example of this, do **not** use the original mysql gem).
 
 
 Usage
 --------------------
 
-Put girl_friday in your Gemfile:
+Put girl\_friday in your Gemfile:
 
     gem 'girl_friday'
 
@@ -46,17 +46,19 @@ The msg parameter to push is just a Hash whose contents are completely up to you
 
 Your message processing block should **not** access any instance data or variables outside of the block.  That's shared mutable state and dangerous to touch!  I also strongly recommend your queue processor block be **VERY** short, ideally just a method call or two.  You can unit test those methods easily but not the processor block itself.
 
+You can call `GirlFriday::WorkQueue.immediate!` to process jobs immediately, which is helpful when testing. `GirlFriday::WorkQueue.queue!` will revert this & jobs will be processed by actors.
+
 
 More Detail
 --------------------
 
-Please see the [girl_friday wiki](https://github.com/mperham/girl_friday/wiki) for more detail and advanced options and tuning.  You'll find details on queue persistence with Redis, implementing clean shutdown, querying runtime metrics and SO MUCH MORE!
+Please see the [girl\_friday wiki](https://github.com/mperham/girl_friday/wiki) for more detail and advanced options and tuning.  You'll find details on queue persistence with Redis, implementing clean shutdown, querying runtime metrics and SO MUCH MORE!
 
 
 Thanks
 --------------------
 
-[Carbon Five](http://carbonfive.com), I write and maintain girl_friday on their clock.
+[Carbon Five](http://carbonfive.com), I write and maintain girl\_friday on their clock.
 
 This gem contains a copy of the Rubinius Actor API, modified to work on any Ruby VM.  Thanks to Evan Phoenix, MenTaLguY and the Rubinius project for permission to use and distribute this code.
 

--- a/lib/girl_friday/work_queue.rb
+++ b/lib/girl_friday/work_queue.rb
@@ -34,6 +34,23 @@ module GirlFriday
     end
     alias_method :<<, :push
 
+    def self.immediate!
+      alias_method :orig_push, :push
+      alias_method :push, :push_immediately
+      alias_method :<<, :push_immediately
+    end
+
+    def self.queue!
+      alias_method :push, :orig_push
+      alias_method :<<, :push
+    end
+
+    def push_immediately(work, &block)
+      result = @processor.call(work)
+      return yield result if block
+      result
+    end
+
     def status
       { @name => {
           :pid => $$,

--- a/test/test_girl_friday_immediately.rb
+++ b/test/test_girl_friday_immediately.rb
@@ -1,0 +1,28 @@
+require 'helper'
+
+class TestGirlFridayImmediately < MiniTest::Unit::TestCase
+
+  def setup
+    GirlFriday::WorkQueue.immediate!
+  end
+
+  def teardown
+    GirlFriday::WorkQueue.queue!
+  end
+
+  def test_should_process_immediately
+    queue = GirlFriday::WorkQueue.new('now') do |msg|
+      msg[:start] + 1
+    end
+    assert_equal 42, queue.push(:start => 41)
+    assert_equal 42, queue << { :start => 41 }
+  end
+
+  def test_should_process_immediately_with_callback
+    queue = GirlFriday::WorkQueue.new('now') do |msg|
+      msg[:start] + 1
+    end
+    assert_equal 43, queue.push(:start => 41) { |r| r + 1 }
+  end
+
+end


### PR DESCRIPTION
WorkQueue.immediate! will cause jobs to run immediately, not by
and actor. WorkQueue.queue! will revert.

Ignore rbc files compiled to .rbxdb
