### PR TITLE
WorkQueue.queue! / WorkQueue.immediate! fix

### DIFF
--- a/test/test_girl_friday_immediately.rb
+++ b/test/test_girl_friday_immediately.rb
@@ -25,4 +25,25 @@ class TestGirlFridayImmediately < MiniTest::Unit::TestCase
     assert_equal 43, queue.push(:start => 41) { |r| r + 1 }
   end
 
+  def test_should_process_style_idempotently
+    queue = GirlFriday::WorkQueue.new('now') do |msg|
+      msg[:start] + 1
+    end
+
+    5.times { GirlFriday::WorkQueue.queue! }
+    5.times { GirlFriday::WorkQueue.immediate! }
+    assert_equal 2, queue.push(:start => 1)
+    assert_equal 2, queue << {:start => 1}
+
+    10.times do |i|
+      if i.odd?
+        GirlFriday::WorkQueue.queue!
+      else
+        GirlFriday::WorkQueue.immediate!
+      end
+    end
+    GirlFriday::WorkQueue.immediate!
+    assert_equal 3, queue.push(:start => 2)
+    assert_equal 3, queue << {:start => 2}
+  end
 end


### PR DESCRIPTION
allow WorkQueue.queue! and WorkQueue.immediate! to be called in any order, as well as ensuring that they are idempotent
