### PR TITLE
fix alias bug (should be alias_method to avoid runtime error)

### DIFF
--- a/lib/girl_friday/work_queue.rb
+++ b/lib/girl_friday/work_queue.rb
@@ -39,7 +39,7 @@ module GirlFriday
 
     if defined?(Rails) && Rails.env.development?
       Rails.logger.debug "[girl_friday] Starting in single-threaded mode for Rails autoloading compatibility" if Rails.logger
-      alias :push_async, :push_immediately
+      alias_method :push_async, :push_immediately
     else
       def push_async(work, &block)
         @supervisor << Work[work, block]

--- a/test/test_girl_friday_immediately.rb
+++ b/test/test_girl_friday_immediately.rb
@@ -46,4 +46,34 @@ class TestGirlFridayImmediately < MiniTest::Unit::TestCase
     assert_equal 3, queue.push(:start => 2)
     assert_equal 3, queue << {:start => 2}
   end
+
+  def test_should_process_immediately_when_rails_dev
+    # remove WorkQueue definitions first, since #push_async is defined
+    # as the class definition is executed, and Rails constant is not defined yet
+    [:Queue, :WorkQueue].each {|c| GirlFriday.send(:remove_const, c)}
+
+    # now top-level Rails constant will exist
+    Object.send(:include, RailsEnvironment)
+
+    # re-load class now that Rails constant is defined
+    $".delete_if {|f| f =~ %r{work_queue.rb}}
+    require 'girl_friday/work_queue'
+
+    # verify that we process immediately
+    queue = GirlFriday::WorkQueue.new('now') do |msg|
+      msg[:start] + 1
+    end
+    assert_equal 4, queue.push(:start => 3)
+    assert_equal 4, queue << {:start => 3}
+  end
+end
+
+module RailsEnvironment
+  class Rails
+    def self.method_missing(m, *args, &block)
+      # swallow every call and return self so that WorkQueue
+      # thinks Rails dev environment is loaded
+      self
+    end
+  end
 end


### PR DESCRIPTION
whoops, a little bug snuck into last night's release:

this will generate a runtime error when we're in Rails dev environment (alias doesn't want commas):

alias :push_async, :push_immediately

the pull request switches this to use alias_method instead.

thanks!

ryan
