### PR TITLE
Use default error handlers if none specified.

### DIFF
--- a/lib/girl_friday/work_queue.rb
+++ b/lib/girl_friday/work_queue.rb
@@ -11,7 +11,7 @@ module GirlFriday
       @name = name.to_s
       @size = options[:size] || 5
       @processor = block
-      @error_handlers = (Array(options[:error_handler]) || ErrorHandler.default).map(&:new)
+      @error_handlers = (Array(options[:error_handler] || ErrorHandler.default)).map(&:new)
 
       @shutdown = false
       @busy_workers = []

--- a/test/test_girl_friday_queue.rb
+++ b/test/test_girl_friday_queue.rb
@@ -36,6 +36,20 @@ class TestGirlFriday < MiniTest::Unit::TestCase
     end
   end
 
+  def test_should_use_a_default_error_handler_when_none_specified
+    async_test do |cb|
+      queue = GirlFriday::WorkQueue.new('error') do |msg|
+      end
+      queue.shutdown do
+        cb.call
+      end
+      queue.push(:text => 'foo') # Redundant
+
+      # Not an ideal method, but I can't see a better way without complex stubbing.
+      assert queue.instance_eval { @error_handlers }.length > 0
+    end
+  end
+
   def test_should_call_callback_when_complete
     async_test do |cb|
       queue = GirlFriday::WorkQueue.new('callback', :size => 1) do |msg|


### PR DESCRIPTION
Currently, all errors are silently swallowed. This is pretty bad.
