### PR TITLE
capture and print exceptions from processor

### DIFF
--- a/lib/girl_friday/work_queue.rb
+++ b/lib/girl_friday/work_queue.rb
@@ -136,9 +136,16 @@ module GirlFriday
           while running? do
             work = Actor.receive
             if running?
-              result = @processor.call(work.msg)
-              work.callback.call(result) if work.callback
-              supervisor << Ready[Actor.current]
+              begin
+                result = @processor.call(work.msg)
+                work.callback.call(result) if work.callback
+              rescue NameError => ex
+                $stderr.print "Processor error in girl_friday for #{name}.\n"
+                $stderr.print("#{ex}\n")
+                $stderr.print("#{ex.backtrace.join("\n")}\n")
+              ensure
+                supervisor << Ready[Actor.current]
+              end
             end
           end
         end


### PR DESCRIPTION
example:

I am integrating girl_friday support into carrierwave_backgrounder and found that, for a mounted uploader with methods like those in Image (below), the call to #type_name would raise a NameError (as it looks for "Image::Image").  Unfortunately, that error was swallowed, leading to silent failures.

This commit highlights the need to change, in this case, "Image::TYPES" to "::Image::TYPES".

class Image < ActiveRecord::Base
  TYPES = [
    ["One", 1],
    ["Two", 2]
  ]

  def filename
    "image-#{type_name}"
  end

  def type_name
    (Image::TYPES.first { |option| option[1] == type_id })[0]
  end
end
