### PR TITLE
remove deprecated HoptoadNotifier

### DIFF
--- a/lib/girl_friday/error_handler.rb
+++ b/lib/girl_friday/error_handler.rb
@@ -3,7 +3,7 @@ module GirlFriday
 
     def self.default
       handlers = [Stderr]
-      handlers << Hoptoad if defined?(HoptoadNotifier)
+      handlers << Airbrake if defined?(::Airbrake)
       handlers
     end
 
@@ -14,12 +14,10 @@ module GirlFriday
       end
     end
 
-    class Hoptoad
+    class Airbrake
       def handle(ex)
-        HoptoadNotifier.notify_or_ignore(ex)
+        ::Airbrake.notify_or_ignore(ex)
       end
     end
-    Airbrake = Hoptoad
-
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -40,3 +40,18 @@ class MiniTest::Unit::TestCase
   end
 
 end
+
+module Faker
+  def initialize
+    @number_of_calls = 0
+  end
+
+  def number_of_calls
+    @number_of_calls
+  end
+
+
+  def count(*args,&blk)
+    @number_of_calls += 1
+  end
+end

--- a/test/test_error_handler.rb
+++ b/test/test_error_handler.rb
@@ -1,0 +1,60 @@
+require 'helper'
+
+
+class TestErrorHandler < MiniTest::Unit::TestCase
+  Stderr = GirlFriday::ErrorHandler::Stderr
+  Airbrake = GirlFriday::ErrorHandler::Airbrake
+
+  class FakeStderr
+    include Faker
+    def flush
+      "WOOSH!"
+    end
+    alias_method :puts, :count
+    alias_method :write, :count
+  end
+
+  class FakeAirbrake
+    include Faker
+    alias_method :notify_or_ignore, :count
+  end
+
+  class FakeError
+    def backtrace
+     %w(
+      We're no strangers to love
+      You know the rules and so do I
+      A full commitment's what I'm thinking of
+      You wouldn't get this from any other guy
+      I just wanna tell you how I'm feeling
+      Gotta make you understand
+     )
+    end
+  end
+
+  def handler
+    GirlFriday::ErrorHandler
+  end
+
+  def test_default
+    assert_equal [Stderr], handler.default
+
+    Object.const_set("Airbrake","super cool error catcher")
+    assert_equal [Stderr,Airbrake], handler.default
+    Object.send(:remove_const,:Airbrake)
+  end
+
+  def test_stderr
+    $stderr = FakeStderr.new
+    Stderr.new.handle(FakeError.new)
+    assert_equal 2, $stderr.number_of_calls
+  end
+
+  def test_airbrake
+    airbrake = FakeAirbrake.new
+    Object.const_set("Airbrake", airbrake)
+    Airbrake.new.handle(FakeError.new)
+    assert_equal 1, airbrake.number_of_calls
+    Object.send(:remove_const,:Airbrake)
+  end
+end


### PR DESCRIPTION
Hey Mike!

I've noticed you're using a [deprecated](https://github.com/thoughtbot/hoptoad_notifier/blob/master/README.md) notifier, so I've updated to Airbrake.

By the way, we've added girl_friday to Airbrake [recently](https://github.com/airbrake/airbrake/commit/7ae3f7e788ba817c5026d27c6c1d0e1aa86c70f5). 

I really like the simplicity, thanks!
