### PR TITLE
Rubinius change does incorrect require, causing name clash

### DIFF
--- a/lib/girl_friday.rb
+++ b/lib/girl_friday.rb
@@ -2,7 +2,7 @@ require 'weakref'
 require 'thread'
 begin
   # Rubinius
-  require 'actor'
+  require 'girl_friday/actor'
   require 'girl_friday/monkey_patches'
 rescue LoadError
   # Others


### PR DESCRIPTION
We are using an actor.rb class in our project, which gets required, causing all kinds of nastyness. Also I'm not really sure what you are trying to do here. You should just require both without the error catching and everything should work fine.
