### PR TITLE
Does not check for work available on the redis queue

### DIFF
--- a/lib/girl_friday.rb
+++ b/lib/girl_friday.rb
@@ -53,7 +53,7 @@ module GirlFriday
   def self.check_for_work
     queues.each do |queue|
       begin
-        queue.__getobj__.check
+        queue.__getobj__.check_for_work
       rescue WeakRef::RefError
       end
     end

--- a/lib/girl_friday.rb
+++ b/lib/girl_friday.rb
@@ -6,18 +6,18 @@ require 'girl_friday/work_queue'
 require 'girl_friday/error_handler'
 require 'girl_friday/persistence'
 require 'girl_friday/batch'
+require 'girl_friday/polling'
 
 begin
   # Rubinius or JRuby
   require 'rubinius/actor'
   GirlFriday::WorkQueue::Actor = Rubinius::Actor
+  GirlFriday::Polling::Actor = Rubinius::Actor
 rescue RuntimeError
   # Rubinius::Actor will raise a RuntimeError when
   # required on !(Rubinius || JRuby)
   require 'girl_friday/actor'
 end
-
-require 'girl_friday/polling'
 
 module GirlFriday
   @lock = Mutex.new

--- a/lib/girl_friday.rb
+++ b/lib/girl_friday.rb
@@ -49,6 +49,16 @@ module GirlFriday
     end
   end
 
+  # Asks each queue to check with its persistence store for work
+  def self.check_for_work
+    queues.each do |queue|
+      begin
+        queue.__getobj__.check
+      rescue WeakRef::RefError
+      end
+    end
+  end
+
   ##
   # Notify girl_friday to shutdown ASAP.  Workers will not pick up any
   # new work; any new work pushed onto the queues will be pushed onto the

--- a/lib/girl_friday/polling.rb
+++ b/lib/girl_friday/polling.rb
@@ -1,0 +1,76 @@
+require 'ruby-debug'
+
+module GirlFriday
+  module Polling
+    DefaultPollingInterval = 15
+
+    Shutdown = Struct.new(:callback)
+
+    @shutting_down = true
+
+    def self.polling_interval
+      @polling_interval ||= DefaultPollingInterval
+    end
+
+    def self.polling_interval=(value)
+      raise ArgumentError, "Infinite time between polls really is not polling at all is it?" if value == 0
+      @polling_interval = value
+    end
+
+    def self.begin_polling
+      @shutting_down = false
+      @pollster ||= Actor.spawn do
+        Thread.current[:label] = "girl-friday-pollster"
+        begin
+          polling_loop
+        rescue Exception => ex
+          $stderr.print "Fatal error in girl_friday: pollster died.\n"
+          $stderr.print("#{ex}\n")
+          $stderr.print("#{ex.backtrace.join("\n")}\n")
+        end
+      end
+      @pollster << :poll
+      polling?
+    end
+
+    def self.end_polling(&block)
+      @shutting_down = true
+      pollster << Shutdown[block] unless pollster.nil?
+    end
+
+    def self.polling?
+      !shutting_down? && !!pollster
+    end
+
+    def self.shutting_down?
+      @shutting_down
+    end
+
+    private
+
+    def self.polling_loop
+      loop do
+        Actor.receive do |f|
+          f.when(:poll) do
+            sleep polling_interval
+            GirlFriday.check_for_work
+            pollster << :poll
+          end
+          f.when(Shutdown) do |stop|
+            @pollster = nil
+            begin
+              stop.callback.call(self) unless stop.callback.nil?
+            rescue Exception => ex
+              handle_error(ex)
+            end
+            return
+          end
+        end
+      end
+    end
+
+    def self.pollster
+      @pollster ||= nil
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -38,6 +38,20 @@ class MiniTest::Unit::TestCase
     puts "Unable to shutdown queue (#{count})" if count != 0
   end
 
+  def with_redis_connection
+    begin
+      require 'redis'
+      require 'connection_pool'
+      pool = ConnectionPool.new(:size => 5, :timeout => 2){ Redis.new }
+      pool.with_connection {|redis| redis.flushdb }
+    rescue LoadError
+      return puts "Skipping redis test, 'redis' gem not found: #{$!.message}"
+    rescue Errno::ECONNREFUSED
+      return puts 'Skipping redis test, not running locally'
+    end
+
+    yield pool
+  end
 end
 
 module Faker

--- a/test/test_girl_friday.rb
+++ b/test/test_girl_friday.rb
@@ -58,6 +58,16 @@ class TestGirlFriday < MiniTest::Unit::TestCase
         assert !GirlFriday.polling?
       end
     end
+
+    describe '.check_for_work' do
+      before do
+        GirlFriday::Queue.new(:q1) do; end
+        GirlFriday::Queue.new(:q2) do; end
+      end
+      it 'should not throw an error' do
+        GirlFriday.check_for_work
+      end
+    end
   end
 
 end

--- a/test/test_girl_friday.rb
+++ b/test/test_girl_friday.rb
@@ -31,6 +31,32 @@ class TestGirlFriday < MiniTest::Unit::TestCase
         assert_in_delta 0, Time.now - a, 0.1
         assert_equal 0, GirlFriday.queues.size
       end
+      it 'stops polling' do
+        GirlFriday.begin_polling
+        GirlFriday.shutdown!
+        assert !GirlFriday.polling?
+      end
+    end
+
+    describe '.begin_polling' do
+      it 'does not poll unless started' do
+        assert !GirlFriday.polling?
+      end
+      it 'polls once started' do
+        assert !GirlFriday.polling?
+        GirlFriday.begin_polling
+        assert GirlFriday.polling?
+      end
+    end
+
+    describe '.end_polling' do
+      before do
+        GirlFriday.begin_polling
+      end
+      it 'stops polling' do
+        GirlFriday.end_polling
+        assert !GirlFriday.polling?
+      end
     end
   end
 

--- a/test/test_girl_friday.rb
+++ b/test/test_girl_friday.rb
@@ -3,6 +3,9 @@ require 'helper'
 class TestGirlFriday < MiniTest::Unit::TestCase
 
   describe 'GirlFriday' do
+    before do
+      GirlFriday::Polling.polling_interval = 1
+    end
     after do
       GirlFriday.shutdown!
     end
@@ -32,30 +35,30 @@ class TestGirlFriday < MiniTest::Unit::TestCase
         assert_equal 0, GirlFriday.queues.size
       end
       it 'stops polling' do
-        GirlFriday.begin_polling
+        GirlFriday::Polling.begin_polling
         GirlFriday.shutdown!
-        assert !GirlFriday.polling?
+        assert !GirlFriday::Polling.polling?
       end
     end
 
     describe '.begin_polling' do
       it 'does not poll unless started' do
-        assert !GirlFriday.polling?
+        assert !GirlFriday::Polling.polling?
       end
       it 'polls once started' do
-        assert !GirlFriday.polling?
-        GirlFriday.begin_polling
-        assert GirlFriday.polling?
+        assert !GirlFriday::Polling.polling?
+        GirlFriday::Polling.begin_polling
+        assert GirlFriday::Polling.polling?
       end
     end
 
     describe '.end_polling' do
       before do
-        GirlFriday.begin_polling
+        GirlFriday::Polling.begin_polling
       end
       it 'stops polling' do
-        GirlFriday.end_polling
-        assert !GirlFriday.polling?
+        GirlFriday::Polling.end_polling
+        assert !GirlFriday::Polling.polling?
       end
     end
 

--- a/test/test_girl_friday_queue.rb
+++ b/test/test_girl_friday_queue.rb
@@ -146,7 +146,7 @@ class TestGirlFridayQueue < MiniTest::Unit::TestCase
     end
   end
 
-  def test_polling_redis_for_work
+  def test_checking_redis_for_work
     with_redis_connection do |pool|
       mutex = Mutex.new
       total = 5

--- a/test/test_girl_friday_queue.rb
+++ b/test/test_girl_friday_queue.rb
@@ -121,37 +121,69 @@ class TestGirlFridayQueue < MiniTest::Unit::TestCase
   end
 
   def test_should_persist_with_redis_connection_pool
-    begin
-      require 'redis'
-      require 'connection_pool'
-      pool = ConnectionPool.new(:size => 5, :timeout => 2){ Redis.new }
-      pool.with_connection {|redis| redis.flushdb }
-    rescue LoadError
-      return puts "Skipping redis test, 'redis' gem not found: #{$!.message}"
-    rescue Errno::ECONNREFUSED
-      return puts 'Skipping redis test, not running locally'
-    end
+    with_redis_connection do |pool|
+      mutex = Mutex.new
+      total = 100
+      count = 0
+      incr = Proc.new do
+        mutex.synchronize do
+          count += 1
+        end
+      end
 
-    mutex = Mutex.new
-    total = 100
-    count = 0
-    incr = Proc.new do
-      mutex.synchronize do
-        count += 1
+      async_test(2.0) do |cb|
+        queue = GirlFriday::WorkQueue.new('redis-pool', :size => 2, :store => GirlFriday::Store::Redis, :store_config => { :pool => pool }) do |msg|
+          incr.call
+          queue.shutdown do
+            cb.call
+          end if count == total
+        end
+        total.times do
+          queue.push(:text => 'foo')
+        end
+        refute_nil queue.status['redis-pool'][:backlog]
       end
     end
+  end
 
-    async_test(2.0) do |cb|
-      queue = GirlFriday::WorkQueue.new('redis-pool', :size => 2, :store => GirlFriday::Store::Redis, :store_config => { :pool => pool }) do |msg|
+  def test_polling_redis_for_work
+    with_redis_connection do |pool|
+      mutex = Mutex.new
+      total = 5
+      count = 0
+      incr = Proc.new do
+        mutex.synchronize do
+          count += 1
+        end
+      end
+
+      # Put stuff on the redis queue
+      queue = GirlFriday::WorkQueue.new('redis-pool', :size => 0, :store => GirlFriday::Store::Redis, :store_config => { :pool => pool }) do |msg|
         incr.call
-        queue.shutdown do
-          cb.call
-        end if count == total
+        queue.shutdown if count == total
       end
       total.times do
         queue.push(:text => 'foo')
       end
-      refute_nil queue.status['redis-pool'][:backlog]
+
+      sleep 0.5 # Need to let these values get stored by redis
+      assert_equal total, queue.status['redis-pool'][:backlog]
+      queue.shutdown
+
+      # Rebuild a redis queue with workers (simulates another queue coming online say in a different process)
+      count = 0
+      queue = GirlFriday::WorkQueue.new('redis-pool', :size => 2, :store => GirlFriday::Store::Redis, :store_config => { :pool => pool }) do |msg|
+        incr.call
+        queue.shutdown if count == total
+      end
+      assert_equal total, queue.status['redis-pool'][:backlog]
+
+      queue.check_for_work
+
+      sleep 0.5 # Need to let our jobs get processed
+      assert_equal 0, queue.status['redis-pool'][:backlog]
+      assert_equal total, queue.status['redis-pool'][:total_processed]
+
     end
   end
 


### PR DESCRIPTION
If one process builds up a backlog of work items, other processes will not jump in to help.

An example could be in a single unicorn that schedules more jobs than it can handle alone or a scheduled rake task that queues work and dies while expecting the servers to handle the long running tasks that run to completion.

My solution was to add what is essentially a no-op on a busy queue to check for work messages in the persistance layer but allows users to request the supervisor reach out to the persister without writing such logic into the message processing block.

I have also implemented a simple pollster in the GirlFriday module. It does not run by default and is turned off on #shutdown!

I have tests for all the logic though I had trouble wrapping my head around what test_async was doing. Please let me know if I can clean any of that up to keep the style more consistent.
